### PR TITLE
Xray connection error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ XRAY_DNS2=https+local://8.8.8.8/dns-query
 XRAY_LOG_LEVEL=info       # info|warning|error
 XRAY_LOG_DIR=~/xray       # default: $HOME/xray
 XRAY_TLS_INSECURE=0       # set 1 untuk skip verifikasi TLS (darurat saja)
+XRAY_ALPN=h2,h3            # override ALPN (opsional)
+XRAY_TLS_FP=chrome         # uTLS fingerprint, alias: XRAY_TLS_FINGERPRINT
+XRAY_DISABLE_MUX=1         # disable MUX untuk stabilitas (default 1)
 ```
 
 Catatan Termux/Android:
@@ -36,4 +39,5 @@ export SSL_CERT_DIR=$PREFIX/etc/tls/certs
 
 Menjalankan aplikasi:
 
+```
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Konfigurasi env (opsional tapi disarankan):
 SECRET_KEY=your-secret
 XRAY_PATH=./xray  # jika menggunakan Xray
 ALLOWED_ORIGINS=http://localhost:5000
+# Opsional: kontrol DNS & logging Xray saat testing real geolocation
+XRAY_DNS_MODE=doh         # doh|udp (default: doh)
+XRAY_DNS1=https+local://1.1.1.1/dns-query
+XRAY_DNS2=https+local://8.8.8.8/dns-query
+XRAY_LOG_LEVEL=info       # info|warning|error
+XRAY_LOG_DIR=~/xray       # default: $HOME/xray
 ```
 
 Menjalankan aplikasi:
@@ -30,7 +36,7 @@ python -c "import app; app.socketio.run(app.app, host='0.0.0.0', port=5000, debu
 Catatan testing:
 
 - Tanpa Xray: tester melakukan TCP connect dan fallback ping; akan ditingkatkan dengan TLS/WS probe.
-- Dengan Xray (opsional): tester melakukan koneksi HTTP melalui proxy untuk mengambil egress IP dan ISP yang real.
+- Dengan Xray (opsional): tester melakukan koneksi HTTP melalui proxy untuk mengambil egress IP dan ISP yang real. DNS menggunakan DoH IPv4-only secara default dan log ditulis ke `~/xray/`.
 
 Keamanan:
 

--- a/README.md
+++ b/README.md
@@ -23,22 +23,17 @@ XRAY_DNS1=https+local://1.1.1.1/dns-query
 XRAY_DNS2=https+local://8.8.8.8/dns-query
 XRAY_LOG_LEVEL=info       # info|warning|error
 XRAY_LOG_DIR=~/xray       # default: $HOME/xray
+XRAY_TLS_INSECURE=0       # set 1 untuk skip verifikasi TLS (darurat saja)
+```
+
+Catatan Termux/Android:
+- Pastikan paket CA terpasang: `pkg install ca-certificates`
+- Jika masih gagal TLS, set env berikut sebelum menjalankan:
+```
+export SSL_CERT_FILE=$PREFIX/etc/tls/cert.pem
+export SSL_CERT_DIR=$PREFIX/etc/tls/certs
 ```
 
 Menjalankan aplikasi:
 
 ```
-python run.py
-# atau
-python -c "import app; app.socketio.run(app.app, host='0.0.0.0', port=5000, debug=False)"
-```
-
-Catatan testing:
-
-- Tanpa Xray: tester melakukan TCP connect dan fallback ping; akan ditingkatkan dengan TLS/WS probe.
-- Dengan Xray (opsional): tester melakukan koneksi HTTP melalui proxy untuk mengambil egress IP dan ISP yang real. DNS menggunakan DoH IPv4-only secara default dan log ditulis ke `~/xray/`.
-
-Keamanan:
-
-- Simpan token GitHub di database, jangan kirim kembali ke frontend.
-- Gunakan `.env` untuk SECRET_KEY dan path Xray.

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import subprocess
 from dotenv import load_dotenv
 from urllib.parse import urlparse
 from io import BytesIO
+import shutil
 
 load_dotenv()
 

--- a/real_geolocation_tester.py
+++ b/real_geolocation_tester.py
@@ -990,6 +990,15 @@ class RealGeolocationTester:
             with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
                 json.dump(cfg, f)
                 tmp = f.name
+            # Also dump a readable copy to XRAY_LOG_DIR for debugging
+            try:
+                access_log, _ = self._get_log_paths()
+                dump_dir = os.path.dirname(access_log)
+                dump_path = os.path.join(dump_dir, 'last_config.json')
+                with open(dump_path, 'w') as df:
+                    json.dump(cfg, df, indent=2)
+            except Exception:
+                pass
             proc = subprocess.Popen([self.xray_path, '-c', tmp], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             return proc, tmp
         

--- a/real_geolocation_tester.py
+++ b/real_geolocation_tester.py
@@ -524,6 +524,14 @@ class RealGeolocationTester:
         else:
             outbound['settings'] = {}
 
+        # MUX control via environment (default: disabled for stability)
+        try:
+            disable_mux = os.getenv('XRAY_DISABLE_MUX', '1').strip().lower() in ('1', 'true', 'yes', 'on')
+        except Exception:
+            disable_mux = True
+        if disable_mux:
+            outbound['mux'] = {"enabled": False}
+
         # Top-level with logs, DNS and inbound binding
         log_level = os.getenv('XRAY_LOG_LEVEL', 'info')
         access_log, error_log = self._get_log_paths()


### PR DESCRIPTION
Configure Xray with DoH DNS and direct logs to home directory to fix connection errors and improve debugging.

The previous setup relied on the system's DNS resolver, which was failing (connection refused on `[::1]:53`). This change hardcodes reliable DoH servers within Xray's configuration, ensuring DNS resolution works independently of the system. It also centralizes Xray's access and error logs in `~/xray/` for easier monitoring and debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-6102109b-fe2e-4015-84c6-18c42a1287ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6102109b-fe2e-4015-84c6-18c42a1287ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

